### PR TITLE
Transfer repository from `hallidave/ruby-snmp` to `ruby-snmp/ruby-snmp`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,8 +5,6 @@
 
 == Summary
 
-THIS LIBRARY IS NO LONGER SUPPORTED. USE AT YOUR OWN RISK.
-
 This library implements SNMP (the Simple Network Management Protocol).  It is
 implemented in pure Ruby, so there are no dependencies on external libraries
 like net-snmp[http://www.net-snmp.org/].  You can run this library anywhere

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = SNMP Library for Ruby
 {<img src="https://travis-ci.com/hallidave/ruby-snmp.svg?branch=master" alt="Build Status" />}[https://travis-ci.com/hallidave/ruby-snmp]
-{<img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT" />}[https://raw.githubusercontent.com/hallidave/ruby-snmp/master/MIT-LICENSE]
+{<img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT" />}[https://raw.githubusercontent.com/ruby-snmp/ruby-snmp/master/MIT-LICENSE]
 {<img src="https://badge.fury.io/rb/snmp.svg" alt="Gem Version" />}[https://badge.fury.io/rb/snmp]
 
 == Summary

--- a/snmp.gemspec
+++ b/snmp.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     s.description = "A Ruby implementation of SNMP (the Simple Network Management Protocol)."
     s.author = 'Dave Halliday'
     s.email = 'hallidave@gmail.com'
-    s.homepage = 'https://github.com/hallidave/ruby-snmp'
+    s.homepage = 'https://github.com/ruby-snmp/ruby-snmp'
     s.license = 'MIT'
     s.required_ruby_version = '>= 1.9.0'
 

--- a/web/content/index.html
+++ b/web/content/index.html
@@ -80,7 +80,7 @@
 	</style>
 </head>
 <body>
-<a href="http://github.com/hallidave/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a> 
+<a href="http://github.com/ruby-snmp/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a> 
 <div id="wrap">
   <img src="rubysnmp.gif" alt="Ruby SNMP" width="290" height="50"/>
 	<div id="main">
@@ -145,7 +145,7 @@ end</code></pre>
     module.&rdquo;</p>
     <p>&ldquo;Your work alone heightens my interest in Ruby quite a bit.&rdquo;</p>
     </div>
-    <p>Have feeback?  Send it <a href="https://github.com/hallidave/ruby-snmp/">via GitHub</a>.</p>
+    <p>Have feeback?  Send it <a href="https://github.com/ruby-snmp/ruby-snmp/">via GitHub</a>.</p>
 		<h3>What is SNMP?</h3>
 		<p>SNMP is the Simple Network Management Protocol.  This protocol provides the capability to monitor and manage switches, routers, printers, desktops, and other equipment in your network.</p>
 


### PR DESCRIPTION
### Summary
The repository has been transferred from `hallidave/ruby-snmp` to `ruby-snmp/ruby-snmp` to continue maintaining the snmp gem.

### Changes
- Change repository URL due to transfer from `hallidave/ruby-snmp` to `ruby-snmp/ruby-snmp`
