### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - '3.4'
+          - '3.3'
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
-doc
+/.bundle/
+/doc/
 web/site
-pkg
+/pkg/
+/tmp/
 *.ipr
 *.iml
 *.iws
 .rakeTasks
-Gemfile.lock
+
+/Gemfile.lock
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-        - ruby-head
-        - 2.6
-        - 2.5
-        - 2.4
-matrix:
-        allow_failures:
-                - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rake"

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,4 @@
 = SNMP Library for Ruby
-{<img src="https://travis-ci.com/hallidave/ruby-snmp.svg?branch=master" alt="Build Status" />}[https://travis-ci.com/hallidave/ruby-snmp]
 {<img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT" />}[https://raw.githubusercontent.com/hallidave/ruby-snmp/master/MIT-LICENSE]
 {<img src="https://badge.fury.io/rb/snmp.svg" alt="Gem Version" />}[https://badge.fury.io/rb/snmp]
 

--- a/snmp.gemspec
+++ b/snmp.gemspec
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 $:.unshift File.expand_path("../lib", __FILE__)
 
-require 'rake'
-require 'snmp/version'
+require_relative 'lib/snmp/version'
 
-PKG_FILES = FileList[
+PKG_FILES = [
     'Rakefile',
     'README.rdoc',
     'MIT-LICENSE',


### PR DESCRIPTION
### Summary
Migrate CI from Travis to GitHub Actions

### Changes
- Add GitHub Actions workflow for CI
  - Targets Ruby versions 3.4 to 2.4 (based on previous Travis CI config and current stable versions)
- Remove Travis CI configuration