### PR TITLE
Require MFA for gem releases

### DIFF
--- a/snmp.gemspec
+++ b/snmp.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ruby-snmp/ruby-snmp"
   spec.metadata["changelog_uri"] = "https://github.com/ruby-snmp/ruby-snmp/blob/master/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
### Summary
This Pull Request adds to require MFA for gem releases.

### Details
Starting with the next release, performing a gem release will require MFA.

@hallidave If you have not yet enabled MFA for RubyGems.org, please confirm your settings and enable it as needed.  

### Related Links
- MFA requirement opt-in - RubyGems Guides
  - https://guides.rubygems.org/mfa-requirement-opt-in/
